### PR TITLE
[resolved] backquotes are forbidden error with rm

### DIFF
--- a/examples/flickr_report.rb
+++ b/examples/flickr_report.rb
@@ -1,4 +1,3 @@
-
 $:.unshift('lib')
 
 require 'rubygems'
@@ -88,7 +87,10 @@ engine.register_participant :generate_result_pdf do |workitem|
   end
   puts ".generated out.pdf"
 
-  `rm pic*.jpg`
+  entries.each_with_index do |entry, i|
+    `rm  "pic#{i}.jpg"`
+     puts "..removed pic#{i}.jpg"
+  end
 end
 
 #


### PR DESCRIPTION
Hi,

there was an other error with deleting the files in the Flickr example.

~Bjoern
