### PR TITLE
re-added add_item method to composite storage

### DIFF
--- a/lib/ruote/storage/composite_storage.rb
+++ b/lib/ruote/storage/composite_storage.rb
@@ -97,8 +97,8 @@ module Ruote
     delegate :get_engine_variable, :variables
     delegate :put_engine_variable, :variables
 
-    #def add_type (type)
-    #end
+    def add_type (type)
+    end
 
     TYPES = %w[
       variables


### PR DESCRIPTION
I came across an issue while using CompositeStorage, its looks like the add_item is required. After uncommenting it looks like my issue was resolved.

After reviewing the interface section of http://ruote.rubyforge.org/implementing_a_storage.html it looks like it should be there, but there may be a reason that it was commented.
