### PR TITLE
Flunk with a string only

### DIFF
--- a/lib/ruote/receiver/base.rb
+++ b/lib/ruote/receiver/base.rb
@@ -78,7 +78,7 @@ module Ruote
       err = error_class_or_instance_or_message
 
       if err.is_a?(String)
-        err = StandardError.new(err)
+        err = RuntimeError.new(err)
         err.set_backtrace(caller)
 
       elsif err.is_a?(Class)

--- a/test/functional/ft_25_receiver.rb
+++ b/test/functional/ft_25_receiver.rb
@@ -251,7 +251,7 @@ class FtReceiverTest < Test::Unit::TestCase
     r = @dashboard.wait_for(wfid)
 
     assert_equal 'error_intercepted', r['action']
-    assert_equal 'StandardError', r['error']['class']
+    assert_equal 'RuntimeError', r['error']['class']
     assert_equal 'out of order', r['error']['message']
     assert_match __FILE__, r['error']['trace'].first
   end


### PR DESCRIPTION
Yields StandardError (like raise)

(i made a whoopsy here; StandardError is the default for rescue - but I like it nevertheless)
