### PR TITLE
wait_for properly returns when :or_error interest is present

### DIFF
--- a/lib/ruote/log/wait_logger.rb
+++ b/lib/ruote/log/wait_logger.rb
@@ -267,7 +267,11 @@ module Ruote
         interests.delete(interest) if satisfied
       end
 
-      (interests.size < 1)
+      if interests.include?(:or_error)
+        (interests.size < 2)
+      else
+        (interests.size < 1)
+      end
     end
   end
 end


### PR DESCRIPTION
When the :or_error argument is passed to Dashboard#wait_for, it returns _only_ if an error occurs. The expected behavior is that wait_for, when passed the :or_error argument, returns when all interests are matched, _or_ when an error occurs. This pull request fixes the bug by causing WaitLogger#wait_for to return true when :or_error is the single remaining interest.
