### PR TITLE
Fix WaitLogger#wait_for when :or_error flag present

### DIFF
--- a/lib/ruote/log/wait_logger.rb
+++ b/lib/ruote/log/wait_logger.rb
@@ -178,8 +178,12 @@ module Ruote
       while @waiting.any? and msg = @seen.shift
 
         @waiting.delete_if do |thread, interests|
-          thread['__result__'] = msg if matches(interests, msg)
-          (interests.size < 1)
+          if matches(interests, msg)
+            thread['__result__'] = msg
+            true
+          else
+            false
+          end
         end
       end
     end

--- a/test/unit/ut_12_wait_logger.rb
+++ b/test/unit/ut_12_wait_logger.rb
@@ -116,6 +116,30 @@ class UtWaitLoggerTest < Test::Unit::TestCase
     assert_equal 'alpha', r['participant_name']
   end
 
+  # this test will *sometimes* fail with WaitLogger#check_waiting
+  # in revision 92adc70950087637ec76fa394f9bb149fd8a61f4 and earlier
+  # due to an elusive race condition that is not possible to replicate
+  # in this test.
+  # with the current code (as of this writing) it will never fail
+  def test_or_error_when_alpha_multiple_interests
+
+    @engine.register :alpha,  Ruote::NoOpParticipant
+    @engine.register :bravo, Ruote::NullParticipant
+
+    d0 = Ruote.define do
+      alpha
+      bravo
+    end
+
+    i0 = @engine.launch(d0)
+
+    r0 = @engine.wait_for(:alpha, :or_error)
+    r1 = @engine.wait_for(:bravo)
+
+    assert_equal 'dispatch', r1['action']
+    assert_equal 'bravo', r1['participant_name']
+  end
+
   def test_wait_for_hash
 
     #@engine.noisy = true


### PR DESCRIPTION
- WaitLogger#check_waiting returns tre or false explicitly based on whether or not the interests match, rather than the number of remaining interests, which may still include the :or_error flag
- adds a test that the expected result is obtained when multiple wait_for calls are in play. It should be noted that the patch eliminates a potential race condition where Thread.current['**result**'] was being overwritten by a later message that did not necessarily match any interests. Reproducing this race condition in the test is extremely challenging, if not impossible.
