### PR TITLE
Using latest version of yajl-ruby

### DIFF
--- a/quickstart/Gemfile
+++ b/quickstart/Gemfile
@@ -1,7 +1,6 @@
-
 source :rubygems
 
-gem 'yajl-ruby', '1.0.0', :require => 'yajl'
+gem 'yajl-ruby', '1.1.0', :require => 'yajl'
 
 #gem 'ruote', '>= 2.3.0'
 #gem 'ruote', :git => 'git://github.com/jmettraux/ruote.git'


### PR DESCRIPTION
Using version 1.1.0 of yajl-ruby to prevent the following exception:

dyld: lazy symbol binding failed: Symbol not found: _yajl_set_static_value
  Referenced from: /Library/Ruby/Gems/1.8/gems/yajl-ruby-1.0.0/lib/yajl/yajl.bundle
  Expected in: flat namespace

dyld: Symbol not found: _yajl_set_static_value
  Referenced from: /Library/Ruby/Gems/1.8/gems/yajl-ruby-1.0.0/lib/yajl/yajl.bundle
  Expected in: flat namespace
