### PR TITLE
Fix exception handling in Receiver#flunk

### DIFF
--- a/lib/ruote/receiver/base.rb
+++ b/lib/ruote/receiver/base.rb
@@ -102,9 +102,13 @@ module Ruote
           err = err.new(*err_arguments)
           err.set_backtrace(trace || caller)
 
+          klass = err.class.name
+          message = err.message
+          backtrace = err.backtrace
+
         else # regular exception, no need to instantiate (class may be remote)
 
-          klass = err
+          klass = err.to_s
           message = err_arguments[0]
           backtrace = err_arguments[1]
 

--- a/test/functional/ft_25_receiver.rb
+++ b/test/functional/ft_25_receiver.rb
@@ -232,7 +232,7 @@ class FtReceiverTest < Test::Unit::TestCase
     end
   end
 
-  class NoInstanciationFlunkParticipant
+  class NonInstantiationFlunkParticipant
     include Ruote::LocalParticipant
 
     # Since LocalParticipant extends ReceiverMixin, we can call #flunk
@@ -261,9 +261,14 @@ class FtReceiverTest < Test::Unit::TestCase
     end
   end
 
-  class MultipleArgumentsError < RuntimeError
+  class ::MultipleArgumentsError < RuntimeError
     def initialize(a, b)
-      self.message = "#{a} #{b}"
+      @a = a
+      @b = b
+    end
+
+    def message
+      "#{@a} #{@b}"
     end
   end
 
@@ -361,7 +366,7 @@ class FtReceiverTest < Test::Unit::TestCase
 
   def test_non_instanciation_flunk
 
-    @dashboard.register :alpha, NonInstanciationFlunkParticipant
+    @dashboard.register :alpha, NonInstantiationFlunkParticipant
 
     wfid =
       @dashboard.launch(Ruote.define do


### PR DESCRIPTION
- Allow storing exceptions without instantiating them, because the class may not be available to the process running Ruote (remote process running ruote-resque for example)
- Reintroduce receiver.flunk(workitem, e)
- Better outline the different cases

I don't think of any case where we really need to instantiate the exception, except maybe a custom exception with multiple parameters, so I kept this part as a legacy.
