### PR TITLE
Uninitialized constant Ruote::PP

### DIFF
--- a/lib/ruote/util/misc.rb
+++ b/lib/ruote/util/misc.rb
@@ -228,7 +228,7 @@ module Ruote
 
   def self.pps(o, w=79)
 
-    PP.pp(o, StringIO.new, w).string
+    ::PP.pp(o, StringIO.new, w).string
   end
 
   #--


### PR DESCRIPTION
Hello John,

Since updating ruote-resque to use Ruote::ReceivedError, I'm getting an exception when navigating to the error page in ruote-kit.
Here is the stack trace

```
NameError - uninitialized constant Ruote::PP:
/app/vendor/bundle/ruby/1.9.1/bundler/gems/ruote-2048bc6ad7c6/lib/ruote/util/misc.rb:231:in `pps'
/app/vendor/bundle/ruby/1.9.1/bundler/gems/ruote-kit-f42ad9295767/lib/ruote-kit/views/error.html.haml:50:in `block in singletonclass'
/app/vendor/bundle/ruby/1.9.1/bundler/gems/ruote-kit-f42ad9295767/lib/ruote-kit/views/error.html.haml:65528:in `instance_eval'
/app/vendor/bundle/ruby/1.9.1/bundler/gems/ruote-kit-f42ad9295767/lib/ruote-kit/views/error.html.haml:65528:in `singletonclass'
/app/vendor/bundle/ruby/1.9.1/bundler/gems/ruote-kit-f42ad9295767/lib/ruote-kit/views/error.html.haml:65526:in `__tilt_14442160'
...
```
