### PR TITLE
Actual working fix for NameError in Ruote.pps

### DIFF
--- a/lib/ruote/util/misc.rb
+++ b/lib/ruote/util/misc.rb
@@ -23,6 +23,7 @@
 #++
 
 require 'socket'
+require 'pp'
 
 
 module Ruote
@@ -228,7 +229,7 @@ module Ruote
 
   def self.pps(o, w=79)
 
-    ::PP.pp(o, StringIO.new, w).string
+    PP.pp(o, StringIO.new, w).string
   end
 
   #--


### PR DESCRIPTION
Hello,

The previous fix (#85) was not working, it's not a namespacing issue, but misc.rb was missing the require for PP.
This time it works, sorry for the previous PR.

Regards,
