### PR TITLE
Avoid deleting all processes if argument is nil

### DIFF
--- a/lib/ruote/storage/base.rb
+++ b/lib/ruote/storage/base.rb
@@ -278,6 +278,7 @@ module Ruote
     # the process.
     #
     def remove_process(wfid)
+      return if wfid.nil?
 
       2.times do
         # two passes

--- a/test/functional/storage.rb
+++ b/test/functional/storage.rb
@@ -580,6 +580,14 @@ class FtStorage < Test::Unit::TestCase
     assert_equal 1, @s.get_many('errors').size
     assert_equal 1, @s.get_trackers['trackers'].size
 
+    @s.remove_process(nil)
+
+    assert_equal 6, @s.get_many('expressions').size
+    assert_equal 1, @s.get_many('schedules').size
+    assert_equal 1, @s.get_many('workitems').size
+    assert_equal 1, @s.get_many('errors').size
+    assert_equal 1, @s.get_trackers['trackers'].size
+
   ensure
     dboard.shutdown rescue nil
   end


### PR DESCRIPTION
If `nil` is passed as an argument to `remove_process` Ruote deletes all the processes in the database. An implicit validation on the function for `nil?` parameter fixes it